### PR TITLE
fix initilizer sorting on bundler for ruby >= 3.4.0

### DIFF
--- a/lib/turnstiled/engine.rb
+++ b/lib/turnstiled/engine.rb
@@ -4,7 +4,7 @@ module Turnstiled
       ActiveSupport.on_load(:action_controller_base) { include Turnstiled::ControllerMethods }
     end
 
-    initializer "turnstiled.controller" do
+    initializer "turnstiled.view_helper" do
       ActiveSupport.on_load(:action_view) { include Turnstiled::ViewHelper }
     end
 


### PR DESCRIPTION
On load the engine would raise an error due to the duplicate named initializer.

/Users/ktlo/.rbenv/versions/3.4.1/lib/ruby/3.4.0/tsort.rb:233:in 'block in TSort.tsort_each': topological sort failed: [#<Rails::Initializable::Initializer:0x0000000151c5ef70 @group=:default, @name="turnstiled.controller", @before=nil, @after=nil, @context=#<Turnstiled::Engine>, @block=#<Proc:0x0000000150c526b8 /Users/ktlo/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/turnstiled-0.1.14/lib/turnstiled/engine.rb:3>>, #<Rails::Initializable::Initializer:0x0000000151c5eed0 @group=:default, @name="turnstiled.controller", @before=nil, @after="turnstiled.controller", @context=#<Turnstiled::Engine>, @block=#<Proc:0x0000000150c52640 /Users/ktlo/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/turnstiled-0.1.14/lib/turnstiled/engine.rb:7>>](TSort::Cyclic)