### PR TITLE
CI: run workflows on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -22,7 +22,7 @@ jobs:
         run: bin/rubocop -f github
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build + Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     permissions:
       contents: write


### PR DESCRIPTION
Development and production both run arm64, so CI was the only x86 environment in the stack.

Every `runs-on: ubuntu-latest` becomes `ubuntu-24.04-arm`. arm64 standard runners [became available in private repositories in January 2026](https://github.blog/changelog/2026-01-29-arm64-standard-runners-are-now-available-in-private-repositories/) and count against the plan's included minutes like any other standard runner.

The actions in use resolve arm64 builds natively, so nothing runs under emulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
