### PR TITLE
Pass size and theme through to the widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ Within a form make sure to render the widget:
 <% end %>
 ```
 
+`turnstile_tag` takes Cloudflare's `size` and `theme`, and passes anything else
+to the `div` it renders:
+
+``` erb
+<%= turnstile_tag size: "flexible", theme: "light", class: "rounded-md" %>
+```
+
+`size` is one of `normal`, `flexible` or `compact`, and defaults to `compact`.
+`theme` is one of `auto`, `light` or `dark`, and defaults to `auto` — which
+follows the visitor's operating system, so a site with no dark mode of its own
+should say `light` rather than take a dark widget on a light page.
+
 In your controller, you also need to verify the response with the following:
 
 ``` ruby

--- a/app/javascript/turnstiled/controllers/turnstile_controller.js
+++ b/app/javascript/turnstiled/controllers/turnstile_controller.js
@@ -3,11 +3,15 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = {
     siteKey: String,
+    size: { type: String, default: "compact" },
+    theme: { type: String, default: "auto" },
   }
 
   connect() {
     turnstile.render(this.element, {
       sitekey: this.siteKeyValue,
+      size: this.sizeValue,
+      theme: this.themeValue,
       callback: this.callback.bind(this),
     })
   }

--- a/lib/turnstiled/view_helper.rb
+++ b/lib/turnstiled/view_helper.rb
@@ -2,13 +2,19 @@
 
 module Turnstiled
   module ViewHelper
-    def turnstile_tag(size: "compact", **options)
+    # `size` and `theme` reach the widget as Stimulus values rather than as the
+    # `data-size`/`data-theme` attributes Cloudflare documents: the script is
+    # loaded with `render=explicit`, and in that mode the widget is drawn from
+    # the object passed to `turnstile.render` and never reads the element.
+    def turnstile_tag(size: "compact", theme: "auto", **options)
       options = options.deep_merge(
         class: "cf-turnstile #{options[:class]}",
         data: {
           sitekey: Turnstiled.site_key,
           controller: "turnstile",
           turnstile_site_key_value: Turnstiled.site_key,
+          turnstile_size_value: size,
+          turnstile_theme_value: theme,
           size:
         }
       )


### PR DESCRIPTION
`turnstile_javascript_tag` loads the script with `render=explicit`. In that mode Cloudflare draws the widget from the object handed to `turnstile.render` and never reads the element, so the `data-*` attributes its docs describe are inert.

Two things follow:

- **`size` has never worked.** The helper writes `data-size`, the controller does not pass it, so `turnstile_tag size: "flexible"` renders a `compact` widget.
- **`theme` was never sent**, leaving Cloudflare's default of `auto` — the visitor's OS decides. An app with no dark mode of its own shows a dark widget on a light page to anyone whose laptop is set that way, and there was no way to say otherwise.

Both now travel as Stimulus values, which is the channel the controller reads. Defaults are unchanged (`compact`, `auto`), so nothing moves for existing callers unless they ask for it.

```erb
<%= turnstile_tag size: "flexible", theme: "light", class: "rounded-md" %>
```

`data-size` is left in place rather than removed, in case anything downstream keys off it.

Found while deploying Tavle, where the sign-in widget came up dark on a light page.